### PR TITLE
fix(design): 全体のpadding削減とinputサイズ統一

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -19,7 +19,7 @@ if (!electron) {
         var spawn = require("child_process").spawn;
         spawn(require("electron"), [__filename].concat(process.argv.slice(2)), {
             stdio: [0, 1, 2]
-        }).on("close", function(code) {
+        }).on("close", function (code) {
             process.exit(code);
         });
     }

--- a/css/index.css
+++ b/css/index.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 .App {
-    padding: 0 10px;
+    padding: 0 4px;
 }
 
 .URLInput {
@@ -75,7 +75,7 @@
     box-sizing: border-box;
     color: #333333;
     outline: none;
-    margin: 0 -10px;
+    margin: 0 -4px;
     min-height: 3em;
     font-family: Monaco, "Andale Mono", "Lucida Console", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
     font-size: 13px;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,11 +8,8 @@ function isJS(file) {
     var fileExt = path.extname(file.relative);
     return fileExt === ".js";
 }
-gulp.task("build", function() {
+gulp.task("build", function () {
     const babelOptions = JSON.parse(fs.readFileSync("./.babelrc", "utf-8"));
     const babelify = babel(babelOptions);
-    return gulp
-        .src("src/**/*", { base: "src" })
-        .pipe(gulpif(isJS, babelify))
-        .pipe(gulp.dest("lib/"));
+    return gulp.src("src/**/*", { base: "src" }).pipe(gulpif(isJS, babelify)).pipe(gulp.dest("lib/"));
 });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 console.log("NODE_ENV: " + process.env.NODE_ENV);
-require('@electron/remote/main').initialize();
+require("@electron/remote/main").initialize();
 if (process.env.NODE_ENV === "development") {
     require("@babel/register");
     // Start Node -> Browser

--- a/src/browser/component/TagSelect.js
+++ b/src/browser/component/TagSelect.js
@@ -35,6 +35,30 @@ function TagSelect({ tags, selectedTags, selectTags, ref }) {
         selectTags(tags);
     };
 
+    // react-selectのスタイルをTitleInputやURLInputと統一
+    const customStyles = {
+        control: (provided) => ({
+            ...provided,
+            padding: "4px 0 4px 0.5em",
+            border: "1px solid #aaaaaa",
+            minHeight: "38px",
+            borderRadius: "0",
+            boxShadow: "none",
+            "&:hover": {
+                border: "1px solid #aaaaaa"
+            }
+        }),
+        valueContainer: (provided) => ({
+            ...provided,
+            padding: "0"
+        }),
+        input: (provided) => ({
+            ...provided,
+            margin: "0",
+            padding: "0"
+        })
+    };
+
     return (
         <div className="EditorToolbar">
             <h2 className="l-header">Tags</h2>
@@ -47,6 +71,7 @@ function TagSelect({ tags, selectedTags, selectTags, ref }) {
                 isClearable
                 placeholder="Select Tag(s)"
                 onChange={handleChange}
+                styles={customStyles}
             />
         </div>
     );

--- a/src/browser/service-manager.js
+++ b/src/browser/service-manager.js
@@ -12,7 +12,7 @@ export default class ServiceManager {
      * @param client
      * @param [isDefaultChecked] is default checked
      */
-    addService({model, client, isDefaultChecked}) {
+    addService({ model, client, isDefaultChecked }) {
         this.services.set(model, client);
         if (isDefaultChecked) {
             this.defaultServices.add(model);
@@ -36,9 +36,9 @@ export default class ServiceManager {
      */
     getTagService() {
         const services = Array.from(this.services.keys());
-        return services.find(service => {
+        return services.find((service) => {
             return service.tagService === true;
-        })
+        });
     }
 
     /**
@@ -54,8 +54,8 @@ export default class ServiceManager {
     }
 
     selectServices(serviceIDs) {
-        return this.getServices().filter(service => {
-            return serviceIDs.some(serviceID => {
+        return this.getServices().filter((service) => {
+            return serviceIDs.some((serviceID) => {
                 return serviceID === service.id;
             });
         });

--- a/src/services/API/OAuthRequest.js
+++ b/src/services/API/OAuthRequest.js
@@ -28,7 +28,7 @@ export default class OAuthRequest {
     get(URL, options) {
         return new Promise((resolve, reject) => {
             console.log("OAuth::get", URL);
-            this.oauth.get(URL, this.accessKey, this.accessSecret, function(error, data, res) {
+            this.oauth.get(URL, this.accessKey, this.accessSecret, function (error, data, res) {
                 if (error) {
                     console.error("response", res);
                     return reject(error);
@@ -42,7 +42,7 @@ export default class OAuthRequest {
         let body = options.body;
         console.log("OAuth::post", URL);
         return new Promise((resolve, reject) => {
-            this.oauth.post(URL, this.accessKey, this.accessSecret, body, function(error, data, res) {
+            this.oauth.post(URL, this.accessKey, this.accessSecret, body, function (error, data, res) {
                 if (error) {
                     console.error("response", res);
                     return reject(error);

--- a/src/services/API/fixme_OAuthRequest.js
+++ b/src/services/API/fixme_OAuthRequest.js
@@ -16,7 +16,7 @@ export default class OAuthRequest {
                 Accept: "application/json",
                 Authorization: Authorization
             }
-        }).then(function(response) {
+        }).then(function (response) {
             return response.json();
         });
     }

--- a/src/services/config-dialog/preload.js
+++ b/src/services/config-dialog/preload.js
@@ -1,12 +1,10 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
-contextBridge.exposeInMainWorld(
-    "api", {
-        submit(value){
-            ipcRenderer.send("finish", value);
-        },
-        onInitialize(listener) {
-            ipcRenderer.on("initialize", (event, request) => listener(request));
-        }
+contextBridge.exposeInMainWorld("api", {
+    submit(value) {
+        ipcRenderer.send("finish", value);
+    },
+    onInitialize(listener) {
+        ipcRenderer.on("initialize", (event, request) => listener(request));
     }
-);
+});

--- a/src/services/config-dialog/prompt.js
+++ b/src/services/config-dialog/prompt.js
@@ -5,9 +5,11 @@ import path from "path";
 
 export default function prompt({ title, message, placeholder }, callback) {
     const mainWindow = new BrowserWindow({
-        width: 300, height: 300, webPreferences: {
-            preload: path.join(__dirname, 'preload.js'),
-        },
+        width: 300,
+        height: 300,
+        webPreferences: {
+            preload: path.join(__dirname, "preload.js")
+        }
     });
     const index = {
         html: path.join(__dirname + "/index.html")

--- a/src/services/hatebu/HatenaAuthentication.js
+++ b/src/services/hatebu/HatenaAuthentication.js
@@ -23,7 +23,7 @@ exports.requireAccess = function requireAccess(callback) {
     console.log("requireAccess: request start");
     hatena
         .startRequest()
-        .then(result => {
+        .then((result) => {
             console.log("requireAccess: response result", result);
             var accessToken = result.accessToken;
             var accessTokenSecret = result.accessTokenSecret;
@@ -34,7 +34,7 @@ exports.requireAccess = function requireAccess(callback) {
             storage.set("hatena", credential);
             callback(null, credential);
         })
-        .catch(error => {
+        .catch((error) => {
             callback(error);
         });
 };

--- a/src/services/jser.info-ping/JSerClient.js
+++ b/src/services/jser.info-ping/JSerClient.js
@@ -22,14 +22,14 @@ export default class JSerInfoPintClient {
 
         function createIssue(issueData, callback) {
             const xhr = new XMLHttpRequest();
-            xhr.onload = function() {
+            xhr.onload = function () {
                 if (200 <= xhr.status && xhr.status < 300) {
                     callback(null, xhr.responseText);
                 } else {
                     callback(new Error(xhr.responseText));
                 }
             };
-            xhr.onerror = function() {
+            xhr.onerror = function () {
                 callback(new Error(xhr.responseText));
             };
             xhr.withCredentials = true;
@@ -44,7 +44,7 @@ export default class JSerInfoPintClient {
                     url: url,
                     description: comment
                 },
-                function(error, response) {
+                function (error, response) {
                     if (error) {
                         reject(error);
                     } else {

--- a/src/share/profile.js
+++ b/src/share/profile.js
@@ -1,9 +1,9 @@
 // LICENSE : MIT
 "use strict";
-exports.start = function() {
+exports.start = function () {
     global.profile_startTime = Date.now();
 };
-exports.stop = function() {
-    var ms = Date.now() - require('@electron/remote').getGlobal("profile_startTime");
+exports.stop = function () {
+    var ms = Date.now() - require("@electron/remote").getGlobal("profile_startTime");
     console.log("profile", ms + "ms");
 };


### PR DESCRIPTION
## Summary
- 全体のpaddingを10pxから4pxに削減してコンパクトなレイアウトに変更
- Title、URL、TagのSelectのinputサイズを統一してUIの一貫性を向上

## 変更内容
- `.App`のpaddingを`0 10px`から`0 4px`に変更
- CodeMirrorエディターのmarginをpaddingに合わせて`0 -4px`に調整
- TagSelectコンポーネントにreact-selectのカスタムスタイルを追加
- TitleInput、URLInput、TagSelectの高さとpaddingを統一

## Test plan
- [x] 既存のテストがすべて成功することを確認
- [x] Prettierによるコードフォーマットが適用されることを確認
- [x] UI要素のサイズが統一されていることを確認

Fixes #34

🤖 Generated with [Claude Code](https://claude.ai/code)