### PR TITLE
fix: CodeMirror 6のエディタ高さ設定を修正

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -76,19 +76,16 @@
     color: #333333;
     outline: none;
     margin: 0 -4px;
-    min-height: 3em;
     font-family: Monaco, "Andale Mono", "Lucida Console", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
     font-size: 13px;
 }
 
 .Editor .cm-content {
-    min-height: 3em;
     padding: 8px;
     line-height: 1.4;
 }
 
 .Editor .cm-scroller {
-    overflow: auto;
     font-family: inherit;
 }
 

--- a/src/browser/component/Editor.js
+++ b/src/browser/component/Editor.js
@@ -85,6 +85,13 @@ export default function Editor({ value, onChange, onSubmit, services, toggleServ
         };
     }, [services.length, toggleServiceAtIndex, onSubmit]); // Ensure toggleServiceAtIndex and onSubmit are memoized in the parent component
 
+    // 最小高さを設定するテーマ
+    const minHeightTheme = EditorView.theme({
+        "&": { height: "auto" },
+        ".cm-content, .cm-gutter": { minHeight: "120px" },
+        ".cm-scroller": { overflow: "auto" }
+    });
+
     const extensions = [
         // 最高優先度でMod+Enterをオーバーライド
         Prec.highest(
@@ -102,6 +109,7 @@ export default function Editor({ value, onChange, onSubmit, services, toggleServ
         ),
         markdown({ codeLanguages: languages }),
         EditorView.lineWrapping,
+        minHeightTheme,
         textlintLinter ? [textlintLinter, lintGutter()] : []
     ]
         .flat()
@@ -115,7 +123,6 @@ export default function Editor({ value, onChange, onSubmit, services, toggleServ
                 onChange={onChange}
                 extensions={extensions}
                 theme="light"
-                height="120px"
                 basicSetup={{
                     lineNumbers: false
                 }}


### PR DESCRIPTION
## 概要
CodeMirror 6のエディタで1行目しかクリックできない問題を修正しました。

## 変更内容
- `EditorView.theme()`を使用して最小高さを正しく設定
- JavaScriptでテーマとして高さ設定を実装（CodeMirror 6の推奨方法）
- 不要なCSSの高さ設定を削除

## 修正前の問題
- エディタの高さが固定されており、1行目しかクリックできない
- 複数行のテキストを入力してもエディタが拡張されない

## 修正後の動作
- エディタ全体がクリック可能
- コンテンツに応じて自動的に高さが拡張される
- 最小高さ120pxを維持

## テスト方法
1. `npm run start`でアプリケーションを起動
2. エディタの任意の場所をクリックして入力開始できることを確認
3. 複数行のテキストを入力して、エディタが自動的に拡張することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)