### PR TITLE
feat: 1Password初期化の並列化と非同期サービス設定の実装

### DIFF
--- a/src/browser/service-instance.js
+++ b/src/browser/service-instance.js
@@ -5,33 +5,75 @@ import ServiceManger from "./service-manager";
 
 // FIXME: use IPC
 const notBundledRequire = require;
+
+// 初期化が完了したかどうかのフラグとPromise
+let initialized = false;
+let initializationPromise = null;
 const manager = new ServiceManger();
-const getServiceNameList = () => {
-    if (process.env.PLAYWRIGHT_TEST === "1" || process.title?.includes("playwright")) {
-        return notBundledRequire("../../tests/fixtures/test-services.js");
-    } else {
-        const serviceModule = notBundledRequire("../service.js");
-        return serviceModule.default || serviceModule;
-    }
-};
-const services = getServiceNameList()
-    .filter((service) => {
-        return service.enabled;
-    })
-    .map((service) => {
-        const { Model, Client } = service.index ? service.index : require(service.indexPath);
-        const client = new Client(service.options);
-        return {
-            model: new Model(),
-            client: client,
-            isDefaultChecked: service.isDefaultChecked && client.isLogin()
-        };
-    });
-services.forEach(({ model, client, isDefaultChecked }) => {
-    manager.addService({
-        model,
-        client,
-        isDefaultChecked
-    });
-});
+
+// 非同期初期化関数
+async function initializeManager() {
+    if (initialized) return manager;
+    if (initializationPromise) return initializationPromise;
+
+    initializationPromise = (async () => {
+        try {
+            let serviceList;
+            if (process.env.PLAYWRIGHT_TEST === "1" || process.title?.includes("playwright")) {
+                serviceList = notBundledRequire("../../tests/fixtures/test-services.js");
+            } else {
+                const serviceModule = notBundledRequire("../service.js");
+                const serviceConfig = serviceModule.default || serviceModule;
+
+                // service.jsがPromiseを返す場合は解決する
+                if (serviceConfig && typeof serviceConfig.then === "function") {
+                    serviceList = await serviceConfig;
+                } else {
+                    serviceList = serviceConfig;
+                }
+            }
+
+            if (!Array.isArray(serviceList)) {
+                throw new Error("Service list is not an array");
+            }
+
+            const services = serviceList
+                .filter((service) => {
+                    return service.enabled;
+                })
+                .map((service) => {
+                    const { Model, Client } = service.index ? service.index : require(service.indexPath);
+                    const client = new Client(service.options);
+                    return {
+                        model: new Model(),
+                        client: client,
+                        isDefaultChecked: service.isDefaultChecked && client.isLogin()
+                    };
+                });
+
+            services.forEach(({ model, client, isDefaultChecked }) => {
+                manager.addService({
+                    model,
+                    client,
+                    isDefaultChecked
+                });
+            });
+
+            initialized = true;
+            return manager;
+        } catch (error) {
+            console.error("Failed to initialize services:", error);
+            throw error;
+        }
+    })();
+
+    return initializationPromise;
+}
+
+// 初期化を待つためのヘルパー関数をエクスポート
+export async function waitForInitialization() {
+    return initializeManager();
+}
+
+// デフォルトエクスポートはmanagerのままだが、使用前に初期化が必要
 export default manager;


### PR DESCRIPTION
## 概要
- 1Password初期化処理を並列化して高速化
- 非同期サービス設定に対応
- 初期化時間を約13秒から数秒に短縮

## 変更内容

### 1. 1Password CLI呼び出しの並列化
- 複数のシークレットを一度のコマンドで取得（バッチ処理）
- セッション管理で認証を一度だけに最適化
- キャッシュ機能で重複取得を防止

### 2. 非同期初期化への対応
- `service.js`がPromiseを返すように変更
- `waitForInitialization`関数でサービス初期化を待機
- ローディング画面を追加してUXを改善

### 3. テストの更新
- Playwrightテストを非同期初期化に対応
- 初期化待機ヘルパー関数を追加
- ローディング画面のテストケースを追加

## パフォーマンス改善
- 初期化時間: 約13秒 → 数秒
- 1Password認証: 複数回 → 1回

🤖 Generated with [Claude Code](https://claude.ai/code)