### PR TITLE
feat: Claude Code連携にタグ提案と関連アイテム連携を追加

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -337,3 +337,11 @@
 .ClaudeCodePreview--error .ClaudeCodePreview-content {
     color: #c62828;
 }
+
+.ClaudeCodePreview-tags {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed #ccc;
+    font-size: 12px;
+    color: #666;
+}

--- a/src/browser/Action/ServiceAction.js
+++ b/src/browser/Action/ServiceAction.js
@@ -214,7 +214,6 @@ export default class ServiceAction extends Action {
         if (config.mcpConfig) {
             args.push("--mcp-config", JSON.stringify(config.mcpConfig));
         }
-        args.push("--output-format", "json");
         args.push("--print", "--dangerously-skip-permissions", prompt);
 
         const claudeProcess = spawn(config.cliPath, args, {
@@ -235,28 +234,25 @@ export default class ServiceAction extends Action {
 
         claudeProcess.on("close", (code) => {
             if (code === 0 && stdout) {
+                // JSONコードブロックを抽出
+                const jsonMatch = stdout.match(/```(?:json)?\s*([\s\S]*?)```/);
                 let parsedResult = { comment: "", tags: [] };
 
-                try {
-                    // CLIのJSON出力をパース
-                    const cliOutput = JSON.parse(stdout);
-                    const resultText = cliOutput.result || "";
-
-                    // resultの中身をJSONとしてパース
+                if (jsonMatch) {
                     try {
-                        parsedResult = JSON.parse(resultText);
-                    } catch {
-                        // フォールバック: resultをそのままcommentとして使用
-                        parsedResult.comment = resultText;
+                        parsedResult = JSON.parse(jsonMatch[1].trim());
+                    } catch (e) {
+                        // フォールバック: 従来のmarkdown形式
+                        const markdownMatch = stdout.match(/```(?:markdown)?\s*([\s\S]*?)```/);
+                        parsedResult.comment = markdownMatch ? markdownMatch[1].trim() : stdout.trim();
                     }
-                } catch {
-                    // CLIのJSON出力パース失敗時のフォールバック
+                } else {
                     parsedResult.comment = stdout.trim();
                 }
 
                 this.dispatch(keys.claudeCodeComplete, {
                     url,
-                    comment: parsedResult.comment || "",
+                    comment: parsedResult.comment,
                     tags: Array.isArray(parsedResult.tags) ? parsedResult.tags : []
                 });
             } else {

--- a/src/browser/App.js
+++ b/src/browser/App.js
@@ -187,6 +187,25 @@ class App extends React.Component {
         };
         const finishEditing = (relatedItem, value) => {
             ServiceAction.finishEditingRelatedItem(relatedItem, value);
+
+            // 関連URL追加時に再推論
+            if (
+                this._claudeCodeConfig?.enabled &&
+                this.state.claudeCode.status !== "loading" &&
+                this.state.URL?.startsWith("http")
+            ) {
+                // 少し遅延を入れてstateが更新されてから実行
+                setTimeout(() => {
+                    const updatedRelatedItems = appContext.ServiceStore.state.relatedItems;
+                    ServiceAction.runClaudeCode(
+                        this.state.URL,
+                        this.state.title,
+                        this._claudeCodeConfig,
+                        updatedRelatedItems,
+                        this.state.tags
+                    );
+                }, 100);
+            }
         };
         const addItem = () => {
             ServiceAction.addRelatedItem();
@@ -194,8 +213,8 @@ class App extends React.Component {
         const submitPostLink = this.postLink.bind(this);
 
         // Claude Code関連
-        const runClaudeCode = (url, title, config) => {
-            ServiceAction.runClaudeCode(url, title, config);
+        const runClaudeCode = (url, title, config, relatedItems = [], availableTags = []) => {
+            ServiceAction.runClaudeCode(url, title, config, relatedItems, availableTags);
         };
         const insertClaudeCodeResult = () => {
             ServiceAction.insertClaudeCodeResult();
@@ -224,6 +243,8 @@ class App extends React.Component {
                         insertResult={insertClaudeCodeResult}
                         clearResult={clearClaudeCodeResult}
                         claudeCodeConfig={this._claudeCodeConfig}
+                        relatedItems={this.state.relatedItems}
+                        availableTags={this.state.tags}
                     />
                 </div>
                 <ViaURLInput URL={this.state.viaURL} updateURL={updateViaURL} />

--- a/src/browser/Store/ServiceStore.js
+++ b/src/browser/Store/ServiceStore.js
@@ -23,7 +23,8 @@ export default class ServiceStore extends Store {
             claudeCode: {
                 status: "idle", // idle | loading | complete | error
                 url: null,
-                result: null,
+                comment: null,
+                tags: [],
                 error: null
             }
         };
@@ -86,7 +87,8 @@ export default class ServiceStore extends Store {
                 claudeCode: {
                     status: "idle",
                     url: null,
-                    result: null,
+                    comment: null,
+                    tags: [],
                     error: null
                 }
             });
@@ -137,18 +139,20 @@ export default class ServiceStore extends Store {
                 claudeCode: {
                     status: "loading",
                     url,
-                    result: null,
+                    comment: null,
+                    tags: [],
                     error: null
                 }
             });
         });
 
-        this.register(keys.claudeCodeComplete, ({ url, result }) => {
+        this.register(keys.claudeCodeComplete, ({ url, comment, tags }) => {
             this.setState({
                 claudeCode: {
                     status: "complete",
                     url,
-                    result,
+                    comment,
+                    tags: tags || [],
                     error: null
                 }
             });
@@ -159,7 +163,8 @@ export default class ServiceStore extends Store {
                 claudeCode: {
                     status: "error",
                     url,
-                    result: null,
+                    comment: null,
+                    tags: [],
                     error
                 }
             });
@@ -170,22 +175,29 @@ export default class ServiceStore extends Store {
                 claudeCode: {
                     status: "idle",
                     url: null,
-                    result: null,
+                    comment: null,
+                    tags: [],
                     error: null
                 }
             });
         });
 
         this.register(keys.claudeCodeInsert, () => {
-            const { claudeCode } = this.state;
-            if (claudeCode.result) {
-                // 結果でコメントを入れ替え
+            const { claudeCode, selectedTags } = this.state;
+            if (claudeCode.comment) {
+                // タグをマージ（重複排除）
+                const newTags = claudeCode.tags || [];
+                const mergedTags = [...new Set([...selectedTags, ...newTags])];
+
+                // 結果でコメントを入れ替え、タグも追加
                 this.setState({
-                    comment: claudeCode.result,
+                    comment: claudeCode.comment,
+                    selectedTags: mergedTags,
                     claudeCode: {
                         status: "idle",
                         url: null,
-                        result: null,
+                        comment: null,
+                        tags: [],
                         error: null
                     }
                 });

--- a/src/browser/component/ClaudeCodeButton.js
+++ b/src/browser/component/ClaudeCodeButton.js
@@ -9,7 +9,9 @@ export default function ClaudeCodeButton({
     runClaudeCode,
     insertResult,
     clearResult,
-    claudeCodeConfig
+    claudeCodeConfig,
+    relatedItems = [],
+    availableTags = []
 }) {
     const prevUrlRef = useRef(url);
     const debounceTimerRef = useRef(null);
@@ -29,7 +31,7 @@ export default function ClaudeCodeButton({
 
             // 1秒後に実行（入力中の連続変更を避ける）
             debounceTimerRef.current = setTimeout(() => {
-                runClaudeCode(url, title, claudeCodeConfig);
+                runClaudeCode(url, title, claudeCodeConfig, relatedItems, availableTags);
             }, 1000);
         }
 
@@ -40,7 +42,7 @@ export default function ClaudeCodeButton({
                 clearTimeout(debounceTimerRef.current);
             }
         };
-    }, [url, title, claudeCodeConfig, runClaudeCode]);
+    }, [url, title, claudeCodeConfig, runClaudeCode, relatedItems, availableTags]);
 
     const handleClick = useCallback(() => {
         if (claudeCode.status === "complete") {
@@ -49,10 +51,10 @@ export default function ClaudeCodeButton({
         } else if (claudeCode.status === "idle" || claudeCode.status === "error") {
             // アイドルまたはエラー状態の場合は実行
             if (url && url.startsWith("http")) {
-                runClaudeCode(url, title, claudeCodeConfig);
+                runClaudeCode(url, title, claudeCodeConfig, relatedItems, availableTags);
             }
         }
-    }, [claudeCode.status, url, title, claudeCodeConfig, runClaudeCode, insertResult]);
+    }, [claudeCode.status, url, title, claudeCodeConfig, runClaudeCode, insertResult, relatedItems, availableTags]);
 
     // 設定が無効またはCLIが設定されていない場合は表示しない
     if (!claudeCodeConfig?.enabled) {
@@ -70,7 +72,7 @@ export default function ClaudeCodeButton({
                 );
             case "complete":
                 return (
-                    <span className="ClaudeCodeButton-complete" title={claudeCode.result}>
+                    <span className="ClaudeCodeButton-complete" title={claudeCode.comment}>
                         AI ✓
                     </span>
                 );

--- a/src/browser/component/ClaudeCodePreview.js
+++ b/src/browser/component/ClaudeCodePreview.js
@@ -21,7 +21,7 @@ export default function ClaudeCodePreview({ claudeCode, insertResult, clearResul
         );
     }
 
-    if (claudeCode.status === "complete" && claudeCode.result) {
+    if (claudeCode.status === "complete" && claudeCode.comment) {
         return (
             <div className="ClaudeCodePreview ClaudeCodePreview--complete">
                 <div className="ClaudeCodePreview-header">
@@ -32,8 +32,11 @@ export default function ClaudeCodePreview({ claudeCode, insertResult, clearResul
                     </button>
                 </div>
                 <div className="ClaudeCodePreview-content" onClick={insertResult} title="クリックで挿入">
-                    {claudeCode.result}
+                    {claudeCode.comment}
                 </div>
+                {claudeCode.tags && claudeCode.tags.length > 0 && (
+                    <div className="ClaudeCodePreview-tags">Tags: {claudeCode.tags.join(", ")}</div>
+                )}
             </div>
         );
     }


### PR DESCRIPTION
## Summary

Claude Code連携機能を拡張し、タグ提案と関連アイテムのコンテキスト連携を追加しました。prompt関数にrelatedItemsとavailableTagsを渡すことで、より文脈に沿った説明文とタグを生成できるようになります。

## Changes

- prompt関数の引数にrelatedItemsとavailableTagsを追加
- Claude Codeの出力形式をJSON(comment, tags)に変更し、タグ提案をサポート
- 関連URL追加時に自動で再推論を実行
- ClaudeCodePreviewにタグ表示エリアを追加
- 挿入時にコメントとタグの両方を反映

## Breaking Changes

- prompt関数のシグネチャが`{ url, title }`から`{ url, title, relatedItems, availableTags }`に変更
- Claude Codeの出力形式がmarkdownからJSONに変更（従来形式もフォールバックでサポート）

## Test Plan

1. Claude Code連携が有効な状態でURLを入力し、AI説明文が生成されることを確認
2. 関連URLを追加した際に再推論が実行されることを確認
3. 生成結果にタグが含まれる場合、プレビューに表示されることを確認
4. 挿入ボタンでコメントとタグの両方が反映されることを確認

close #47 